### PR TITLE
Add PySide2 viewport example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Blender_my_Maya
 An Open Source project for creating Pyside6 based widget interfaces and tools for making Maya feel and behave like Blender
+
+## PySide2 Viewport Example
+
+The `pyside2_viewport_app.py` script demonstrates how to create a simple
+PySide2 based window that embeds a Maya 3D viewport. To launch the window
+within Maya, run the following in the Script Editor:
+
+```python
+import pyside2_viewport_app
+pyside2_viewport_app.show()
+```

--- a/pyside2_viewport_app.py
+++ b/pyside2_viewport_app.py
@@ -1,0 +1,36 @@
+from maya import cmds
+from maya import OpenMayaUI as omui
+from maya.app.general import mayaMixin
+from PySide2 import QtWidgets
+import shiboken2
+
+class ViewportWindow(mayaMixin.MayaQWidgetDockableMixin, QtWidgets.QWidget):
+    """Simple window that embeds a Maya 3D viewport."""
+
+    def __init__(self, parent=None):
+        super(ViewportWindow, self).__init__(parent=parent)
+        self.setWindowTitle("PySide2 Viewport Example")
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        panel_name = cmds.modelPanel(menuBarVisible=False)
+        ptr = omui.MQtUtil.findControl(panel_name)
+        if ptr:
+            widget = shiboken2.wrapInstance(int(ptr), QtWidgets.QWidget)
+            layout.addWidget(widget)
+        else:
+            label = QtWidgets.QLabel("Could not create modelPanel")
+            layout.addWidget(label)
+
+
+def show():
+    """Utility function to display the viewport window."""
+    global _window
+    try:
+        _window.close()
+        _window.deleteLater()
+    except Exception:
+        pass
+    _window = ViewportWindow()
+    _window.show(dockable=True)


### PR DESCRIPTION
## Summary
- add a PySide2 script showing how to embed a Maya viewport widget
- document viewport example in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68439886e91c83338b68ced852f01165